### PR TITLE
Fix msvc compilation

### DIFF
--- a/libmobile/commands.h
+++ b/libmobile/commands.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 struct mobile_adapter;
 
-#ifdef __cplusplus
+#if defined(__cplusplus) || defined(_MSC_VER)
 #define _Atomic
 #endif
 

--- a/libmobile/serial.h
+++ b/libmobile/serial.h
@@ -5,7 +5,7 @@
 #include "commands.h"
 struct mobile_adapter;
 
-#ifdef __cplusplus
+#if defined(__cplusplus) || defined(_MSC_VER)
 #define _Atomic
 #endif
 


### PR DESCRIPTION
As far as I know, msvc doesn't have a drop in replacement for _Atomic as gcc has, in this commit I just disable them like it's done with C++.